### PR TITLE
chore: Add upload-song.zip to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ dist/
 *.css.map
 *.scss.map
 
+# This is the plugin zip file that wp-scripts generates
+upload-song.zip
+
 # TypeScript cache and output
 *.tsbuildinfo
 tsconfig.tsbuildinfo


### PR DESCRIPTION
## What Changed?

### Dev
- Update gitignore to exclude wp-scripts generated plugin